### PR TITLE
Convert relative links to absolute links

### DIFF
--- a/size-plugin.json
+++ b/size-plugin.json
@@ -1,1 +1,1 @@
-[{"timestamp":1585427306325,"files":[{"filename":"browser-polyfill.min.js","previous":3098,"size":0,"diff":-3098},{"filename":"copy-as-markdown.js","previous":6224,"size":6224,"diff":0}]}]
+[{"timestamp":1587928915757,"files":[{"filename":"copy-as-markdown.js","previous":6224,"size":6285,"diff":61}]},{"timestamp":1585427306325,"files":[{"filename":"browser-polyfill.min.js","previous":3098,"size":0,"diff":-3098},{"filename":"copy-as-markdown.js","previous":6224,"size":6224,"diff":0}]}]


### PR DESCRIPTION
Closes #6.

Uses `element.href = element.href` trick to update relative URLs. The later gives the absolute URL, even if the `href` attribute contains a relative URL, setting that property updates `href` attribute.

This in turn produces the required result, because turndown uses `element.getAtribute('href')` instead of `element.href`([source](https://github.com/domchristie/turndown/blob/4e36b454cf76a5356330aebc97e13e93cd3c1649/src/commonmark-rules.js#L171)).

Also did some renaming of variables, and improving readability of code.