### PR TITLE
Remove unused permissions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,6 @@ The extension requires the following permission from you for working.
 
 1. `contextMenus`: to show option when right-clicking.
 1. `activeTab`: to be able to access content on page.
-1. `clipboardWrite`: to be able to write data to clipboard (we still can’t read from your clipboard).
 
 
 ## Credits

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -16,8 +16,7 @@
 	},
 	"permissions": [
 		"contextMenus",
-		"activeTab",
-		"nativeMessaging"
+		"activeTab"
 	],
 	"action": {
 		"default_icon": "copy-as-markdown.png"


### PR DESCRIPTION
Fixes #45

This was never required in the first place. The Chrome release is also stuck because of this. I did not read the following note at Chrome developer docs before making the MV3 changes in #44.

> Most members of this API do not require any permissions. This permission is needed for [connectNative()](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-connectNative), [sendNativeMessage()](https://developer.chrome.com/docs/extensions/reference/api/runtime#method-sendNativeMessage) and [onNativeConnect](https://developer.chrome.com/docs/extensions/reference/api/runtime#event-onConnectNative).
>
> - https://developer.chrome.com/docs/extensions/reference/api/runtime

Remove this permission and also the note in readme about a permission that is not listed anymore.